### PR TITLE
update commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Before you being, you'll need to install [GPGTools GPG Suite](https://gpgtools.o
 Now, generate the keys. Start a Terminal session, then issue the following commands and options:
 
 ```bash
-> gpg2 --card-edit
+> gpg --card-edit
 
 [truncated...]
 
@@ -174,10 +174,10 @@ _Not sure if you have to logout/login or not here, to ensure GPG Tools can picku
 
 Now, we'll convert your GPG public key to a SSH public key and add it to a server.
 
-1. `> gpg2 --card-edit`
+1. `> gpg --card-edit`
 1. From the text that gets displayed (either automatically, or via the `gpg/card> list` command, grab the last 8 digits of the Authentication key hex code (let's say they are `EEEE FFFF` for the example)
 1. `gpg-card> quit`
-1. `gpgkey2ssh EEEEFFFF`
+1. `gpg --export-ssh-key EEEEFFFF`
 1. Copy the public key and add it to the machine you want to SSH into
 1. Attempt to login to the machine via SSH
 


### PR DESCRIPTION
Thanks for the guide, I found out certain commands didn't work out of the box for me, and after some debugging, here is what worked for me.

### `command not found: gpg2`
Turns out I had `gpg2` installed but it worked via `gpg`

```sh
➜  brew list gpg2
/usr/local/Cellar/gnupg/2.2.20/bin/addgnupghome
/usr/local/Cellar/gnupg/2.2.20/bin/applygnupgdefaults
/usr/local/Cellar/gnupg/2.2.20/bin/dirmngr
/usr/local/Cellar/gnupg/2.2.20/bin/dirmngr-client
/usr/local/Cellar/gnupg/2.2.20/bin/gpg
/usr/local/Cellar/gnupg/2.2.20/bin/gpg-agent
/usr/local/Cellar/gnupg/2.2.20/bin/gpg-connect-agent
/usr/local/Cellar/gnupg/2.2.20/bin/gpg-wks-server
/usr/local/Cellar/gnupg/2.2.20/bin/gpgconf
/usr/local/Cellar/gnupg/2.2.20/bin/gpgparsemail
/usr/local/Cellar/gnupg/2.2.20/bin/gpgscm
/usr/local/Cellar/gnupg/2.2.20/bin/gpgsm
/usr/local/Cellar/gnupg/2.2.20/bin/gpgtar
/usr/local/Cellar/gnupg/2.2.20/bin/gpgv
/usr/local/Cellar/gnupg/2.2.20/bin/kbxutil
/usr/local/Cellar/gnupg/2.2.20/bin/symcryptrun
/usr/local/Cellar/gnupg/2.2.20/bin/watchgnupg
/usr/local/Cellar/gnupg/2.2.20/libexec/ (6 files)
/usr/local/Cellar/gnupg/2.2.20/share/doc/ (23 files)
/usr/local/Cellar/gnupg/2.2.20/share/gnupg/ (30 files)
/usr/local/Cellar/gnupg/2.2.20/share/info/ (3 files)
/usr/local/Cellar/gnupg/2.2.20/share/locale/ (28 files)
/usr/local/Cellar/gnupg/2.2.20/share/man/ (19 files)
```

```sh
➜ which gpg2
gpg2 not found
```

```shell
➜  gpg --version
gpg (GnuPG) 2.2.20
libgcrypt 1.8.5
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Home: /Users/mali/.gnupg
Supported algorithms:
Pubkey: RSA, ELG, DSA, ECDH, ECDSA, EDDSA
Cipher: IDEA, 3DES, CAST5, BLOWFISH, AES, AES192, AES256, TWOFISH,
        CAMELLIA128, CAMELLIA192, CAMELLIA256
Hash: SHA1, RIPEMD160, SHA256, SHA384, SHA512, SHA224
Compression: Uncompressed, ZIP, ZLIB, BZIP2
```

### `command not found: gpgkey2ssh`

However, the following worked 

```
gpg --export-ssh-key EEEEFFFF
```

[gpgkey2ssh has gone, --export-ssh-key is here.
](https://lists.gnupg.org/pipermail/gnupg-devel/2016-January/030682.html)